### PR TITLE
Remove whitespace and fix indent in generated forms

### DIFF
--- a/lib/rails/generators/form/templates/form.rb
+++ b/lib/rails/generators/form/templates/form.rb
@@ -1,9 +1,9 @@
 <% module_namespacing do -%>
 class <%= class_name %>Form < ActiveForm::Base
-  <% if attributes.present? %>
-    attributes <%= attributes.map {|a| ":#{a.name}" }.join(", ") %>
-  <% else %>
+<%- if attributes.present? -%>
+  attributes <%= attributes.map {|a| ":#{a.name}" }.join(", ") %>
+<%- else -%>
   # attributes :name, :email
-  <% end %>
+<%- end -%>
 end
 <% end -%>


### PR DESCRIPTION
Before
rails g form test
```` ruby
class TestForm < ActiveForm::Base
  
  # attributes :name, :email
  
end
````
rails g form test city_id
```` ruby
class TestForm < ActiveForm::Base
  
    attributes :city_id
  
end
````

After
rails g form test
```` ruby
class TestForm < ActiveForm::Base
  # attributes :name, :email
end
````

rails g form test city_id  
```` ruby
class TestForm < ActiveForm::Base
  attributes :city_id
end